### PR TITLE
broken docker repository path

### DIFF
--- a/deepstream.io-complete-backend/docker-compose.yml
+++ b/deepstream.io-complete-backend/docker-compose.yml
@@ -13,7 +13,7 @@ services:
             - rethinkdb
     deepstream-search-provider:
         # build: "../deepstream.io-provider-search-rethinkdb/1.1.1"
-        image: deepstreamio/deepstream.io-provider-search-rethinkdb
+        image: deepstreamio/provider-search-rethinkdb
         environment:
             - DEEPSTREAM_HOST=deepstream
             - DEEPSTREAM_PORT=6021


### PR DESCRIPTION
The path to the docker repository broke and did not get fixed. The github path is still okay but the docker hub path changed. It will fix the path issue but the build of the image is failing (which needs an other fix).